### PR TITLE
[FIX] Badges background color

### DIFF
--- a/mumbletemps/templates/mumbletemps/link.html
+++ b/mumbletemps/templates/mumbletemps/link.html
@@ -44,9 +44,9 @@
 
                     <div class="card-body">
                         <p>{% translate "If you have problems with the application link above, please use the following in Mumble's connection dialog." %}</p>
-                        <p>{% translate "Mumble URL" %}: <span class="badge">{{ mumble }}</span></p>
-                        <p>{% translate "Username" %}: <span class="badge">{{ temp_user.username }}</span></p>
-                        <p>{% translate "Password" %}: <span class="badge">{{ temp_user.password }}</span></p>
+                        <p>{% translate "Mumble URL" %}: <span class="badge bg-dark">{{ mumble }}</span></p>
+                        <p>{% translate "Username" %}: <span class="badge bg-dark">{{ temp_user.username }}</span></p>
+                        <p>{% translate "Password" %}: <span class="badge bg-dark">{{ temp_user.password }}</span></p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### This MR attempts:
Badges unfortunately don't have a default background color but white font.
Which is terrible when having the Flatly theme or any other light theme active.
![image](https://github.com/Solar-Helix-Independent-Transport/allianceauth-mumble-temp/assets/2989985/8325852f-f89e-457f-b951-b30ce117f55a)

This MR changes the background colour to this:
![image](https://github.com/Solar-Helix-Independent-Transport/allianceauth-mumble-temp/assets/2989985/46a09084-4c6d-42ee-a9dc-78f697a00d0a)

