### PR TITLE
[FIX] Bootstrap class on `select` element

### DIFF
--- a/mumbletemps/templates/mumbletemps/index.html
+++ b/mumbletemps/templates/mumbletemps/index.html
@@ -45,7 +45,7 @@
 
                     <div class="mb-3">
                         <label for="time">{% translate "Duration (hours)" %}</label>
-                        <select class="form-control" name="time" id="time">
+                        <select class="form-select" name="time" id="time">
                             <option value="3">3</option>
                             <option value="6">6</option>
                             <option value="12">12</option>


### PR DESCRIPTION
Now we've got the chevron back on the select field.

### Before
![image](https://github.com/Solar-Helix-Independent-Transport/allianceauth-mumble-temp/assets/2989985/1af988df-1cd0-4cf9-8df5-5f1dfad86684)

### Now
![image](https://github.com/Solar-Helix-Independent-Transport/allianceauth-mumble-temp/assets/2989985/43e927b5-130d-4b43-92de-6cf5be063208)
